### PR TITLE
autotornado: support tornado >= 4.5 as well.

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,8 +6,9 @@ Changelog
 Version 1.6.1
 `````````````
 
-To be released.
-
+- Made :mod:`sphinxcontrib.autohttp.tornado` compatible with Tornado 4.5 and
+  newer.  `Tornado 4.5 <http://www.tornadoweb.org/en/stable/releases/v4.5.0.html>`
+  removed the ``handlers`` attribute from ``tornado.web.Application``.
 
 Version 1.6.0
 `````````````

--- a/sphinxcontrib/autohttp/tornado.py
+++ b/sphinxcontrib/autohttp/tornado.py
@@ -47,7 +47,13 @@ def translate_tornado_rule(app, rule):
 
 
 def get_routes(app):
-    for spec in app.handlers[0][1]:
+    if hasattr(app, 'handlers'):  # tornado < 4.5
+        handlers = app.handlers[0][1]
+    elif hasattr(app, 'wildcard_router'):  # tornado > 4.5
+        handlers = app.wildcard_router.rules
+    else:  # unexpected changes
+        raise RuntimeError('get_routes cannot find routes')
+    for spec in handlers:
         handler = spec.handler_class
         doc_methods = list(handler.SUPPORTED_METHODS)
         if 'HEAD' in doc_methods:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py36,py35,py27}-{sphinx16,sphinx15}-{flask12,flask11}-{bottle12,bottle11}
+    {py36,py35,py27}-{sphinx16,sphinx15}-{flask12,flask11}-{bottle12,bottle11}-{tornado44,tornado45}
 
 [testenv]
 deps =
@@ -11,7 +11,8 @@ deps =
     flask12: Flask >= 0.11, < 0.13
     bottle11: bottle >= 0.11.0, < 0.12.0
     bottle12: bottle >= 0.12.0, < 0.13.0
-    tornado <= 4.4.9
+    tornado44: tornado >= 4.4, < 4.5
+    tornado45: tornado >= 4.5, < 4.6
     pytest >= 3.3.2, < 4.0.0
 commands =
     # test links


### PR DESCRIPTION
Tornado recently discarded the `tornado.web.Application.handlers` attribute in preference to using the new routing layer.  This PR changes `autohttp.tornado.get_routes` to recognize older and newer versions of Tornado.