### PR TITLE
Remove sphinx.util.compat references

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,9 @@ Version 1.7.0
 
 To be released.
 
+- Remove references to the ``sphinx.util.compat`` module which was deprecated
+  in Sphinx 1.6 and removed in 1.7.
+
 
 Version 1.6.0
 `````````````

--- a/sphinxcontrib/autohttp/bottle.py
+++ b/sphinxcontrib/autohttp/bottle.py
@@ -14,11 +14,10 @@ import re
 import six
 
 from docutils import nodes
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import directives, Directive
 from docutils.statemachine import ViewList
 
 from sphinx.util import force_decode
-from sphinx.util.compat import Directive
 from sphinx.util.nodes import nested_parse_with_titles
 from sphinx.util.docstrings import prepare_docstring
 from sphinx.pycode import ModuleAnalyzer

--- a/sphinxcontrib/autohttp/flask.py
+++ b/sphinxcontrib/autohttp/flask.py
@@ -16,11 +16,10 @@ import itertools
 import six
 
 from docutils import nodes
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import directives, Directive
 from docutils.statemachine import ViewList
 
 from sphinx.util import force_decode
-from sphinx.util.compat import Directive
 from sphinx.util.nodes import nested_parse_with_titles
 from sphinx.util.docstrings import prepare_docstring
 from sphinx.pycode import ModuleAnalyzer

--- a/sphinxcontrib/autohttp/flask_base.py
+++ b/sphinxcontrib/autohttp/flask_base.py
@@ -15,10 +15,9 @@ import itertools
 import six
 import collections
 
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import directives, Directive
 
 from sphinx.util import force_decode
-from sphinx.util.compat import Directive
 from sphinx.util.docstrings import prepare_docstring
 from sphinx.pycode import ModuleAnalyzer
 

--- a/sphinxcontrib/autohttp/tornado.py
+++ b/sphinxcontrib/autohttp/tornado.py
@@ -15,11 +15,10 @@ import re
 import six
 
 from docutils import nodes
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import directives, Directive
 from docutils.statemachine import ViewList
 
 from sphinx.util import force_decode
-from sphinx.util.compat import Directive
 from sphinx.util.nodes import nested_parse_with_titles
 from sphinx.util.docstrings import prepare_docstring
 from sphinx.pycode import ModuleAnalyzer


### PR DESCRIPTION
The compat module was deprecated in Sphinx 1.6 and removed in Sphinx
1.7[0]. Since it was just importing Directive from docutils.parsers.rst,
this is a simple fix to remain compatible with Sphinx 1.7+.

[0] http://www.sphinx-doc.org/en/master/changes.html#
release-1-7-0-released-feb-12-2018

Signed-off-by: Jeremy Cline <jeremy@jcline.org>