### PR TITLE
Implement autoquickref option

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,9 @@ Version 1.6.2
 
 To be released.
 
+- Implement ``:autoquickref:`` option that use available informations to
+  build a ``quickref``. [:pull:`9` by Alexandre Bonnetain]
+
 
 Version 1.6.1
 `````````````


### PR DESCRIPTION
Hello,

I think that often, when you use the quickref option on a concrete application, blueprint's name and first line of description are what you use as quickref arguments. I implemented an option to automatically populate the quickref table with that in mind.

I am a bit disappointed that the option is also available on the `autoflask` directive, but doing otherwise would necesitate more rewriting to move some functionnalities in children classes and I didn't want to mess up with the code without approval first. I can try if you like the idea though.

I hope you'll like that contribution! 