### PR TITLE
Fix changelog file location in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
      | grep '\[changelog skip\]' > /dev/null; then
     echo "Skip changelog checker..."
   elif [[ "$TRAVIS_TAG" != "" ]]; then
-    ! grep -i "to be released" CHANGES.rst
+    ! grep -i "to be released" doc/changelog.rst
   else
     [[ "$TRAVIS_COMMIT_RANGE" = "" ]] || \
     [[ "$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep doc/changelog\.rst)" != "" ]]


### PR DESCRIPTION
After what you told me in #9, I think it's best to revert this change since it will not work at the next release. At least that's what I understand, but there's a problem anyway since `CHANGES.rst` doesn't exist.