### PR TITLE
Update links to use https

### DIFF
--- a/sphinxcontrib/httpdomain.py
+++ b/sphinxcontrib/httpdomain.py
@@ -55,7 +55,7 @@ class RFC2616Ref(DocRef):
     In 2014, RFC2616 was replaced by multiple RFCs (7230-7237)."""
 
     def __init__(self, section):
-        url = 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec{0:d}.html'
+        url = 'https://www.w3.org/Protocols/rfc2616/rfc2616-sec{0:d}.html'
         url = url.format(int(section))
         super(RFC2616Ref, self).__init__(url, 'sec', section)
 
@@ -71,7 +71,7 @@ class IETFRef(DocRef):
 class EventSourceRef(DocRef):
 
     def __init__(self, section):
-        url = 'http://www.w3.org/TR/eventsource/'
+        url = 'https://www.w3.org/TR/eventsource/'
         super(EventSourceRef, self).__init__(url, section, '')
 
 
@@ -79,7 +79,7 @@ class CORSRef(DocRef):
     """Represents a reference to W3 Cross-Origin Resource Sharing recommendation."""
 
     def __init__(self, name, type):
-        url = 'http://www.w3.org/TR/cors/'
+        url = 'https://www.w3.org/TR/cors/'
         super(CORSRef, self).__init__(url, name, '-' + type)
 
 
@@ -485,19 +485,19 @@ class HTTPXRefStatusRole(XRefRole):
         elif status is None:
             return report_unknown_code()
         elif code == 226:
-            url = 'http://www.ietf.org/rfc/rfc3229.txt'
+            url = 'https://www.ietf.org/rfc/rfc3229.txt'
         elif code == 418:
-            url = 'http://www.ietf.org/rfc/rfc2324.txt'
+            url = 'https://www.ietf.org/rfc/rfc2324.txt'
         elif code == 429:
-            url = 'http://tools.ietf.org/html/rfc6585#section-4'
+            url = 'https://tools.ietf.org/html/rfc6585#section-4'
         elif code == 449:
-            url = 'http://msdn.microsoft.com/en-us/library/dd891478(v=prot.10).aspx'
+            url = 'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wdv/83ecf19f-e0f8-4706-aae5-ba618f52f100'
         elif code == 451:
-            url = 'http://www.ietf.org/rfc/rfc7725.txt'
+            url = 'https://www.ietf.org/rfc/rfc7725.txt'
         elif code in WEBDAV_STATUS_CODES:
-            url = 'http://tools.ietf.org/html/rfc4918#section-11.%d' % (WEBDAV_STATUS_CODES.index(code) + 1)
+            url = 'https://tools.ietf.org/html/rfc4918#section-11.%d' % (WEBDAV_STATUS_CODES.index(code) + 1)
         elif code in HTTP_STATUS_CODES:
-            url = 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html' \
+            url = 'https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html' \
                   '#sec10.' + ('%d.%d' % (code // 100, 1 + code % 100))
         else:
             url = ''


### PR DESCRIPTION
The http links produce warnings from linkcheck that they trigger
a redirection.