### PR TITLE
Url regexp

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -787,6 +787,12 @@ will be rendered as:
 
       .. versionadded:: 1.1.2
 
+    ``url_regexp``
+      Filters urls by filtering out based on a regexp instance built based
+      on the regular expression passed here as a string.
+
+      .. versionadded:: 1.8.1
+
 .. _Flask: http://flask.pocoo.org/
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -788,8 +788,9 @@ will be rendered as:
       .. versionadded:: 1.1.2
 
     ``url_regexp``
-      Filters urls by filtering out based on a regexp instance built based
-      on the regular expression passed here as a string.
+      Filters urls by matching based on a regexp instance built based
+      on the regular expression passed here as a string. The ones not matching
+      are discarded.
 
       .. versionadded:: 1.8.1
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def readme():
 
 setup(
     name='sphinxcontrib-httpdomain',
-    version='1.8.0',
+    version='1.8.1',
     url='https://github.com/sphinx-contrib/httpdomain',
     download_url='https://pypi.org/project/sphinxcontrib-httpdomain/',
     license='BSD',

--- a/sphinxcontrib/autohttp/flask_base.py
+++ b/sphinxcontrib/autohttp/flask_base.py
@@ -40,13 +40,15 @@ def translate_werkzeug_rule(rule):
     return buf.getvalue()
 
 
-def get_routes(app, endpoint=None, order=None):
+def get_routes(app, endpoint=None, order=None, url_regexp=None):
     endpoints = []
     for rule in app.url_map.iter_rules(endpoint):
         url_with_endpoint = (
             six.text_type(next(app.url_map.iter_rules(rule.endpoint))),
             rule.endpoint
         )
+        if url_regexp and not url_regexp.match(url_with_endpoint[0]):
+            continue
         if url_with_endpoint not in endpoints:
             endpoints.append(url_with_endpoint)
     if order == 'path':
@@ -128,6 +130,7 @@ class AutoflaskBase(Directive):
                    'undoc-modules': directives.unchanged,
                    'undoc-static': directives.unchanged,
                    'include-empty-docstring': directives.unchanged,
+                   'url_regexp': directives.unchanged,
                    'autoquickref': directives.flag}
 
     @property
@@ -186,6 +189,13 @@ class AutoflaskBase(Directive):
             return frozenset()
         return frozenset(re.split(r'\s*,\s*', groupby))
 
+    @property
+    def url_regexp(self):
+        url_regexp = self.options.get('url_regexp', None)
+        if url_regexp:
+            return re.compile(url_regexp)
+        return None
+
     def inspect_routes(self, app):
         """Inspects the views of Flask.
 
@@ -193,10 +203,10 @@ class AutoflaskBase(Directive):
         :returns: 4-tuple like ``(method, paths, view_func, view_doc)``
         """
         if self.endpoints:
-            routes = itertools.chain(*[get_routes(app, endpoint, self.order)
+            routes = itertools.chain(*[get_routes(app, endpoint, self.order, url_regexp=self.url_regexp)
                                        for endpoint in self.endpoints])
         else:
-            routes = get_routes(app, order=self.order)
+            routes = get_routes(app, order=self.order, url_regexp=self.url_regexp)
 
         for method, paths, endpoint in routes:
             try:


### PR DESCRIPTION
New string flag: `url_regexp`

Filters urls by matching based on a regexp instance built based on the regular expression passed here as a string. The ones not matching are discarded.