### PR TITLE
Remove imports and calls to depracated function force_decode

### DIFF
--- a/sphinxcontrib/autohttp/bottle.py
+++ b/sphinxcontrib/autohttp/bottle.py
@@ -17,7 +17,6 @@ from docutils import nodes
 from docutils.parsers.rst import directives, Directive
 from docutils.statemachine import ViewList
 
-from sphinx.util import force_decode
 from sphinx.util.nodes import nested_parse_with_titles
 from sphinx.util.docstrings import prepare_docstring
 from sphinx.pycode import ModuleAnalyzer
@@ -89,11 +88,10 @@ class AutobottleDirective(Directive):
                 continue
             view = target.callback
             docstring = view.__doc__ or ''
-            if not isinstance(docstring, six.text_type):
-                analyzer = ModuleAnalyzer.for_module(view.__module__)
-                docstring = force_decode(docstring, analyzer.encoding)
+            
             if not docstring and 'include-empty-docstring' not in self.options:
                 continue
+            
             docstring = prepare_docstring(docstring)
             for line in http_directive(method, path, docstring):
                 yield line

--- a/sphinxcontrib/autohttp/flask.py
+++ b/sphinxcontrib/autohttp/flask.py
@@ -19,7 +19,6 @@ from docutils import nodes
 from docutils.parsers.rst import directives, Directive
 from docutils.statemachine import ViewList
 
-from sphinx.util import force_decode
 from sphinx.util.nodes import nested_parse_with_titles
 from sphinx.util.docstrings import prepare_docstring
 from sphinx.pycode import ModuleAnalyzer

--- a/sphinxcontrib/autohttp/flask_base.py
+++ b/sphinxcontrib/autohttp/flask_base.py
@@ -17,7 +17,6 @@ import collections
 
 from docutils.parsers.rst import directives, Directive
 
-from sphinx.util import force_decode
 from sphinx.util.docstrings import prepare_docstring
 from sphinx.pycode import ModuleAnalyzer
 
@@ -236,9 +235,6 @@ class AutoflaskBase(Directive):
             if view_func and view_func.__doc__:
                 view_doc = view_func.__doc__
 
-            if not isinstance(view_doc, six.text_type):
-                analyzer = ModuleAnalyzer.for_module(view.__module__)
-                view_doc = force_decode(view_doc, analyzer.encoding)
 
             if not view_doc and 'include-empty-docstring' not in self.options:
                 continue

--- a/sphinxcontrib/autohttp/tornado.py
+++ b/sphinxcontrib/autohttp/tornado.py
@@ -18,7 +18,6 @@ from docutils import nodes
 from docutils.parsers.rst import directives, Directive
 from docutils.statemachine import ViewList
 
-from sphinx.util import force_decode
 from sphinx.util.nodes import nested_parse_with_titles
 from sphinx.util.docstrings import prepare_docstring
 from sphinx.pycode import ModuleAnalyzer
@@ -129,11 +128,10 @@ class AutoTornadoDirective(Directive):
                 continue
 
             docstring = getattr(handler, method).__doc__ or ''
-            #if not isinstance(docstring, unicode):
-            #    analyzer = ModuleAnalyzer.for_module(view.__module__)
-            #    docstring = force_decode(docstring, analyzer.encoding)
+            
             if not docstring and 'include-empty-docstring' not in self.options:
                 continue
+            
             docstring = prepare_docstring(docstring)
             for line in http_directive(method, normalize_path(path), docstring):
                 yield line


### PR DESCRIPTION
The depracated function force_decode was removed starting with sphinx 4.0 and is no longer necessary with python 3 [https://github.com/sphinx-doc/sphinx/pull/5620](url)

