### PR TITLE
Add HTTP status code 425 (Too Early)

### DIFF
--- a/sphinxcontrib/httpdomain.py
+++ b/sphinxcontrib/httpdomain.py
@@ -229,6 +229,7 @@ HTTP_STATUS_CODES = {
     422: _('Unprocessable Entity'),
     423: _('Locked'),
     424: _('Failed Dependency'),
+    425: _('Too Early'),
     426: _('Upgrade Required'),
     429: _('Too Many Requests'),
     449: _('Retry With'),           # proprietary MS extension


### PR DESCRIPTION
Fixes `ERROR: 425 is unknown HTTP status code`

[RFC 8470](https://www.ietf.org/rfc/rfc8470.html)