### PR TITLE
Update version 2.0.0 release status in changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,7 @@ Changelog
 Version 2.0.0
 `````````````
 
-unreleased
-
+Released on February 4, 2026
 
 Breaking changes
 ................


### PR DESCRIPTION
Hello, I was just updating an RTD/Sphinx project and looking at dependencies, and noticed that the changelog says "unreleased" for the latest version, which according to github and pypi was released last week.

I followed the format of past releases in the changelog.