### PR TITLE
fix: drop license classifier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Minor changes
 .............
 
 - Fix author email format. [:issue:`99` by @gboutry and @stevepiercy]
+- Drop deprecated license classifier. [:issue:`101` by @gboutry]
 
 
 Version 2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
     "Framework :: Sphinx :: Domain",
     "Framework :: Sphinx :: Extension",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
License classifiers have been deprecated in PEP-639, in the favor of the license and license-files fields.

Fixes: #101