### PR TITLE
Keep the signature anchor when :noindex: is set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Breaking changes
 Major changes
 .............
 
+- Keep the per-page signature anchor and permalink when ``:noindex:`` is set; only the global route registration is skipped. [:pull:`112` by @ggiesen]
 - Added support for Python 3.10 up to 3.14.[:pull:`85` by @stevepiercy]
 - Adjusted a unit test regular expression for :file:`bottle_test.py`. [:pull:`85` by @stevepiercy]
 - Use MDN documentation for information about HTTP status codes instead of ``w3.org``. [:pull:`78` by @jamesrobson-secondmind]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,20 @@
 Changelog
 ---------
 
+Unreleased
+``````````
+
+
+Major changes
+.............
+
+- Keep the per-page signature anchor and permalink when ``:noindex:`` is set; only the global route registration is skipped. [:pull:`112` by @ggiesen]
+
+
 Version 2.0.0
 `````````````
 
-unreleased
+Released on February 4, 2026
 
 
 Breaking changes

--- a/src/sphinxcontrib/httpdomain/__init__.py
+++ b/src/sphinxcontrib/httpdomain/__init__.py
@@ -310,6 +310,23 @@ class HTTPResource(ObjectDescription):
     }
 
     method = NotImplemented
+    noindex = False
+
+    def run(self):
+        # ObjectDescription.run() skips add_target_and_index() entirely when
+        # the noindex option is set, which would drop the per-page anchor
+        # along with the global registration. Anchors are per-document ids
+        # and cannot collide across pages, so pop the option before running
+        # the base class and gate only the registration in
+        # add_target_and_index().
+        self.noindex = 'noindex' in self.options
+        self.options.pop('noindex', None)
+        nodes = super().run()
+        if self.noindex:
+            for node in nodes:
+                if isinstance(node, addnodes.desc):
+                    node['noindex'] = node['no-index'] = True
+        return nodes
 
     def handle_signature(self, sig, signode):
         method = self.method.upper() + ' '
@@ -343,7 +360,7 @@ class HTTPResource(ObjectDescription):
 
     def add_target_and_index(self, name_cls, sig, signode):
         signode['ids'].append(http_resource_anchor(*name_cls[1:]))
-        if 'noindex' not in self.options:
+        if not self.noindex:
             self.env.domaindata['http'][self.method][sig] = (
                 self.env.docname,
                 self.options.get('synopsis', ''),

--- a/test/noindex_test.py
+++ b/test/noindex_test.py
@@ -1,0 +1,70 @@
+import pathlib
+import tempfile
+import unittest
+
+from sphinx import addnodes
+from sphinx.application import Sphinx
+
+
+class NoindexTestCase(unittest.TestCase):
+    """The noindex option must skip only the global route registration.
+
+    The per-page anchor on the signature (and with it the HTML permalink)
+    must survive, so pages that document a route already indexed by another
+    page keep working deep links.
+    """
+
+    def build(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        src = pathlib.Path(self.tmp.name, 'src')
+        src.mkdir()
+        (src / 'conf.py').write_text(
+            "extensions = ['sphinxcontrib.httpdomain']\n"
+        )
+        (src / 'index.rst').write_text(
+            'Index\n'
+            '=====\n'
+            '\n'
+            '.. toctree::\n'
+            '\n'
+            '   other\n'
+            '\n'
+            '.. http:post:: /demo\n'
+            '\n'
+            '   Canonical description.\n'
+        )
+        (src / 'other.rst').write_text(
+            'Other\n'
+            '=====\n'
+            '\n'
+            '.. http:post:: /demo\n'
+            '   :noindex:\n'
+            '\n'
+            '   Alternative description of the same route.\n'
+        )
+        out = pathlib.Path(self.tmp.name, 'out')
+        app = Sphinx(
+            str(src), str(src), str(out), str(out / '.doctrees'), 'html',
+            status=None,
+        )
+        app.build()
+        return app
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_noindex_skips_registration(self):
+        app = self.build()
+        entries = app.env.domaindata['http']['post']
+        self.assertIn('/demo', entries)
+        self.assertEqual(entries['/demo'][0], 'index')
+
+    def test_noindex_keeps_anchor(self):
+        app = self.build()
+        doctree = app.env.get_doctree('other')
+        ids = [
+            anchor
+            for node in doctree.findall(addnodes.desc_signature)
+            for anchor in node['ids']
+        ]
+        self.assertEqual(ids, ['post--demo'])


### PR DESCRIPTION
Fixes #111.

`add_target_and_index()` already expresses the intended split - the per-page anchor is appended unconditionally and only the global route registration is gated behind `:noindex:` - but `ObjectDescription.run()` skips the whole method when the option is set (at least since Sphinx 2.4.5), so the anchor and the HTML permalink were dropped along with the registration.

Handle the option in `HTTPResource.run()` instead: record it, pop it before running the base class (so `add_target_and_index()` is called), keep the anchor, and gate only the registration. The informational `noindex`/`no-index` attributes on the `desc` node are preserved. On Sphinx 7.2+ the pop also happens before the base class normalizes the legacy spelling into `no-index`, so behaviour is identical across the supported range.

Anchors are per-document ids, so restoring them cannot introduce collisions; only the global registration participates in `merge_domaindata()`, which is where duplicate routes are (order-dependently) detected in parallel builds.

Includes a build-level test covering both halves: the `:noindex:`'d copy of a route documented on another page keeps its `post--demo` anchor, and the domain data contains only the canonical page's registration. The anchor assertion fails without the fix; the registration assertion passes with and without, matching the analysis.

Validated with `pytest` (full suite) and `sphinx-build -W -b html docs` on Sphinx 8.1.3 (the locked dev version), and the new tests additionally against Sphinx 6.2.1, 7.0.1, and 7.4.7.

Real-world motivation: saltstack/salt documents overlapping routes on three pages and hit nondeterministic `duplicate HTTP post method definition` failures in `-W -j auto` CI builds (saltstack/salt#69724); `:noindex:` on the non-canonical copies fixes that but currently costs the anchors, which this change makes unnecessary to trade away.
