### PR TITLE
Correct transposed header aliases in documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Internal
 Documentation
 .............
 
+- Corrected the transposed ``<header`` and ``>header`` request and response aliases. [:issue:`24`]
 - Simplified and updated documentation requirements in :file:`rtd-requires.txt`. [:pull:`85` by @stevepiercy]
 - Added a :file:`.readthedocs.yaml` configuration for Read the Docs builds. [:pull:`85` by @stevepiercy]
 - Added omitted change log entries for v1.8.1. [:pull:`85` by @stevepiercy]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -426,12 +426,12 @@ nicely:
 
       :>json boolean status: Operation status
 
-``requestheader``, ``reqheader``, ``>header``
+``requestheader``, ``reqheader``, ``<header``
    Description of request header field.
 
    .. versionadded:: 1.1.9
 
-``responseheader``, ``resheader``, ``<header``
+``responseheader``, ``resheader``, ``>header``
    Description of response header field.
 
    .. versionadded:: 1.1.9


### PR DESCRIPTION
## Summary

- document `<header` as the shorthand request-header directive alias
- document `>header` as the shorthand response-header directive alias
- add the required changelog entry

## Root cause

The narrative documentation transposed the two shorthand aliases. The implementation already defines `<header` for request headers and `>header` for response headers, and the existing RST test fixture uses those correct forms.

## Validation

- `.venv\Scripts\tox.exe r -e py313`
  - Sphinx 9.1.0 HTML build with warnings treated as errors succeeded
  - pytest: 3 passed
- `git diff --check HEAD^..HEAD`
- checked the generated HTML for the corrected request and response alias listings

No new fixture was added because `test/index.rst` already exercises both shorthand directives; this change only corrects their narrative description.

## AI disclosure

This documentation correction was prepared with OpenAI Codex-assisted automation. I reviewed the diff, checked it against the implementation and existing tests, and reran the validation above before submission.

Fixes #24.
